### PR TITLE
Replace deprecated Tailwind imports

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,5 +1,5 @@
-@import "tailwindcss/preflight";
-@import "tailwindcss/utilities";
+@tailwind base;
+@tailwind utilities;
 
 :root {
   --background: #ffffff;


### PR DESCRIPTION
## Summary
- switch `app/globals.css` to use `@tailwind` directives

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6884959c881483209e131a1ebe7f1339