### PR TITLE
Update README to remove font reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+This starter uses the default system fonts provided by Tailwind CSS. No external fonts are loaded or optimized.
 
 ## Learn More
 


### PR DESCRIPTION
## Summary
- remove mention of `next/font` and Geist fonts in README
- clarify that default system fonts are used

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6884959b054c8320a9e34eab0203ad67