### PR TITLE
Fix package name typo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "anclorapresss-ui",
+  "name": "anclorapress-ui",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "anclorapresss-ui",
+      "name": "anclorapress-ui",
       "version": "0.1.0",
       "dependencies": {
         "next": "15.4.4",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "anclorapresss-ui",
+  "name": "anclorapress-ui",
   "version": "0.1.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary
- correct the package name to `anclorapress-ui`
- update the lock file via `npm install`

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_68849cf4cd6483209cccbcac2622b663